### PR TITLE
Final details

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,95 @@
-# visionf1-webapp
-Web app of the VisionF1 project.
+# VisionF1 Webapp
+
+VisionF1 is a comprehensive Formula 1 analytics and prediction platform designed to provide fans and analysts with deep insights into race strategies, performance metrics, and outcome predictions. By leveraging advanced data visualization and AI-driven models, VisionF1 offers a unique perspective on the sport.
+
+## Project Overview
+
+This web application serves as the interactive frontend for the VisionF1 ecosystem. It consumes data from the VisionF1 API to display real-time standings, detailed race analytics, and predictive models. The platform is built for performance and responsiveness, ensuring a seamless experience across devices.
+
+## Features
+
+### Dashboard
+- **Real-Time Standings**: Up-to-date driver and team championship standings.
+- **Upcoming Grand Prix**: Countdown and detailed information about the next race weekend.
+- **Interactive Visuals**: Engaging animations and visual elements to highlight key data points.
+
+### Advanced Analytics
+- **Race Pace Analysis**: Deep dive into driver performance with lap-by-lap pace comparisons.
+- **Clean Air Performance**: Metric analysis filtering out traffic to reveal true car potential.
+- **Lap Time Distributions**: Statistical breakdown of lap times to assess consistency and variability.
+
+### AI & Machine Learning Models
+- **Race Predictions**: AI-powered forecasts for race results based on historical data and current conditions.
+- **Qualifying Predictions**: Estimates for qualifying performance, including gap-to-pole calculations.
+- **Strategy Optimization**: Simulation of optimal pit stop strategies using Monte Carlo methods and tyre degradation models.
+
+### User Interface
+- **Responsive Design**: Fully optimized for desktop, tablet, and mobile viewing.
+- **Dynamic Charts**: Interactive graphs and charts powered by Recharts for clear data interpretation.
+- **Dark Mode**: Sleek, eye-friendly dark theme for comfortable viewing during night races.
+
+## Technology Stack
+
+### Frontend
+- **Framework**: Next.js 16
+- **Language**: TypeScript
+- **Library**: React
+- **Styling**: Tailwind CSS, Shadcn UI
+- **Icons**: Lucide React
+
+### Data Visualization
+- **Charts**: Recharts & Plotly
+
+### State & Data Management
+- **Fetching**: React Server Components, Native Fetch API
+
+## Getting Started
+
+Follow these instructions to set up the project locally for development and testing purposes.
+
+### Prerequisites
+- **Node.js**: Version 18.17 or higher
+- **npm**: Version 9 or higher
+
+### Installation
+
+1.  **Clone the repository**
+    ```bash
+    git clone https://github.com/visionf1/visionf1-webapp.git
+    cd visionf1-webapp
+    ```
+
+2.  **Install dependencies**
+    ```bash
+    npm install
+    ```
+
+3.  **Environment Configuration**
+    Create a `.env.local` file in the root directory and configure the following environment variables:
+    ```env
+    NEXT_PUBLIC_VISIONF1_API_URL=https://api.visionf1.com
+    NEXT_PUBLIC_VISIONF1_PREDICTIONS_API_URL=https://predictions.visionf1.com
+    ```
+    *Note: Replace the URLs with your local or staging API endpoints if applicable.*
+
+4.  **Run the development server**
+    ```bash
+    npm run dev
+    ```
+
+5.  **Access the application**
+    Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
+## Project Structure
+
+A brief overview of the key directories in `visionf1/app`:
+
+- `analytics/`: Pages and components for race pace and performance analysis.
+- `models/`: Interfaces for AI prediction models (Race, Quali, Strategy).
+- `drivers/`: Driver profiles using dedicated components.
+- `components/`: Reusable UI components including charts, tables, and cards.
+- `lib/`: Utility functions and API request handlers.
+
+## License
+
+This project is licensed under the MIT License.

--- a/visionf1/app/analytics/clean-air-head-to-head/page.tsx
+++ b/visionf1/app/analytics/clean-air-head-to-head/page.tsx
@@ -1,0 +1,251 @@
+"use client"
+
+import { useMemo, useState, useEffect } from "react"
+import Image from "next/image"
+
+import { GenericComboBox } from "@/components/ui/combobox"
+import { Spinner } from "@/components/ui/spinner"
+import { HeadToHeadCard } from "@/components/head-to-head-card"
+
+import { getSeasons, getSummaryEvents, getCleanAirRacePace } from "@/lib/api-requests"
+import { Season, EventSummary, CleanAirRacePaceRow, RacePaceRow } from "@/lib/types"
+
+interface TeamComparison {
+  teamName: string;
+  winner: RacePaceRow;
+  loser?: RacePaceRow;
+  delta?: number;
+}
+
+export default function CleanAirHeadToHead() {
+  const [seasons, setSeasons] = useState<Season[]>([]);
+  const [events, setEvents] = useState<EventSummary[]>([]);
+  const [cleanAirData, setCleanAirData] = useState<CleanAirRacePaceRow[]>([]);
+  const [selectedYear, setSelectedYear] = useState<string | null>(null);
+  const [selectedGP, setSelectedGP] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Load seasons on component mount
+  useEffect(() => {
+    const loadSeasons = async () => {
+      try {
+        const seasonsResponse = await getSeasons();
+        setSeasons(seasonsResponse.data);
+      } catch (error) {
+        console.error("Error loading seasons:", error);
+      }
+    };
+
+    loadSeasons();
+  }, []);
+
+  // Load events when a year is selected
+  useEffect(() => {
+    const loadEvents = async () => {
+      if (!selectedYear) return;
+
+      try {
+        const eventsResponse = await getSummaryEvents(Number(selectedYear));
+        setEvents(eventsResponse.data);
+        setSelectedGP(null); // Reset selected GP
+        setCleanAirData([]); // Clear previous data
+      } catch (error) {
+        console.error("Error loading events:", error);
+        setEvents([]);
+      }
+    };
+
+    loadEvents();
+  }, [selectedYear]);
+
+  // Load clean air race pace data when a GP is selected
+  useEffect(() => {
+    const loadRacePace = async () => {
+      if (!selectedGP) return;
+
+      try {
+        setLoading(true);
+        const [season, round] = selectedGP.split('_').map(Number);
+        const response = await getCleanAirRacePace(season, round);
+        // Filter out null or zero values to ensure valid head to head
+        const validData = response.data.filter((d: CleanAirRacePaceRow) => d.avg_laptime_clean_air != null && d.avg_laptime_clean_air > 0);
+        setCleanAirData(validData);
+      } catch (error) {
+        console.error("Error loading clean air race pace data:", error);
+        setCleanAirData([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadRacePace();
+  }, [selectedGP]);
+
+  const years = useMemo(() =>
+    seasons.map(season => String(season)).sort((a, b) => Number(b) - Number(a)),
+    [seasons]
+  );
+
+  const gps = useMemo(() =>
+    events.map(event => ({
+      id: `${event.season}_${event.round}`,
+      label: event.event_name,
+      season: event.season,
+      round: event.round
+    })),
+    [events]
+  );
+
+  const currentEvent = events.find(event =>
+    `${event.season}_${event.round}` === selectedGP
+  );
+
+  // Process data for Head to Head
+  const teamComparisons: TeamComparison[] = useMemo(() => {
+    if (!cleanAirData.length) return [];
+
+    const groupedByTeam: Record<string, RacePaceRow[]> = {};
+
+    // Group drivers by team and map to RacePaceRow format for usage in HeadToHeadCard
+    cleanAirData.forEach(row => {
+      const racePaceRow: RacePaceRow = {
+        ...row,
+        avg_laptime: row.avg_laptime_clean_air,
+        driver: row.driver,
+        driver_color: row.driver_color,
+        driver_first_name: row.driver_first_name,
+        driver_last_name: row.driver_last_name,
+        driver_position: row.driver_position,
+        race_pace_id: row.clean_air_race_pace_id,
+        race_pace_position: row.clean_air_race_pace_position,
+        std_laptime: row.std_laptime_clean_air,
+        team_color: row.team_color,
+        team_name: row.team_name,
+        team: row.team,
+        event: row.event,
+        season: row.season,
+        round: row.round
+      };
+
+      if (!groupedByTeam[row.team_name]) {
+        groupedByTeam[row.team_name] = [];
+      }
+      groupedByTeam[row.team_name].push(racePaceRow);
+    });
+
+    const comparisons: TeamComparison[] = [];
+
+    Object.entries(groupedByTeam).forEach(([teamName, drivers]) => {
+      // Sort by lap time (lower is better/winner)
+      const sortedDrivers = [...drivers].sort((a, b) => a.avg_laptime - b.avg_laptime);
+
+      if (sortedDrivers.length >= 2) {
+        const winner = sortedDrivers[0];
+        const loser = sortedDrivers[1];
+        const delta = loser.avg_laptime - winner.avg_laptime;
+
+        comparisons.push({
+          teamName,
+          winner,
+          loser,
+          delta
+        });
+      } else if (sortedDrivers.length === 1) {
+        // Single driver case
+        comparisons.push({
+          teamName,
+          winner: sortedDrivers[0]
+        });
+      }
+    });
+
+    return comparisons.sort((a, b) => a.teamName.localeCompare(b.teamName));
+
+  }, [cleanAirData]);
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-4">
+      <div className="bg-popover min-h-min flex-1 rounded-xl md:min-h-min p-4">
+        <div className="w-full">
+          <h2 className="text-lg font-semibold pb-4">
+            {currentEvent ? `Clean Air Head to Head - ${currentEvent.season} ${currentEvent.event_name}` : "Clean Air Head to Head"}
+          </h2>
+
+          <div className="flex flex-col sm:flex-row gap-4 mb-4">
+            <GenericComboBox
+              items={years}
+              value={selectedYear}
+              onChange={setSelectedYear}
+              getLabel={(y) => String(y)}
+              getValue={(y) => String(y)}
+              placeholder="Select Year"
+              search_label="Year"
+              width="w-[320px]"
+            />
+
+            <GenericComboBox
+              items={gps}
+              value={selectedGP}
+              onChange={setSelectedGP}
+              getLabel={(g) => `R${g.round} • ${g.label}`}
+              getValue={(g) => g.id}
+              placeholder="Select Grand Prix"
+              search_label="Grand Prix"
+              width="w-[320px]"
+            />
+          </div>
+
+          {loading ? (
+            <div className="flex justify-center items-center h-64">
+              <Spinner className="size-6 mr-2" />
+              <div className="text-lg">Loading clean air data...</div>
+            </div>
+          ) : teamComparisons.length > 0 ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-2 gap-4">
+              {teamComparisons.map((comparison) => (
+                <HeadToHeadCard
+                  key={comparison.teamName}
+                  winner={comparison.winner}
+                  loser={comparison.loser}
+                  delta={comparison.delta}
+                />
+              ))}
+            </div>
+          ) : selectedGP ? (
+            <div className="flex flex-col justify-center items-center text-center h-80 gap-10">
+              <div className="text-lg">No comparable clean air data available for this event.</div>
+              <div className="flex-shrink-0 pb-2 px-2">
+                <div className="h-20 w-20 @2xs:h-24 @2xs:w-24 @xs:h-28 @xs:w-28 @sm:h-36 @sm:w-36 @md:h-42 @md:w-42 @lg:h-46 @lg:w-46 @xl:h-56 @xl:w-56 bg-sidebar-primary border-2 border-brand flex items-center justify-center rounded-full overflow-hidden shadow-lg">
+                  <Image
+                    src="/visionf1-logo.svg"
+                    alt="VisionF1"
+                    width={200}
+                    height={200}
+                    className="object-contain h-full w-full p-1"
+                    loading="eager"
+                  />
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-col justify-center items-center text-center h-80 gap-10">
+              <div className="text-lg">Please select a Grand Prix to view Head to Head comparisons.</div>
+              <div className="flex-shrink-0 pb-2 px-2">
+                <div className="h-20 w-20 @2xs:h-24 @2xs:w-24 @xs:h-28 @xs:w-28 @sm:h-36 @sm:w-36 @md:h-42 @md:w-42 @lg:h-46 @lg:w-46 @xl:h-56 @xl:w-56 bg-sidebar-primary border-2 border-brand flex items-center justify-center rounded-full overflow-hidden shadow-lg">
+                  <Image
+                    src="/visionf1-logo.svg"
+                    alt="VisionF1"
+                    width={200}
+                    height={200}
+                    className="object-contain h-full w-full p-1"
+                    loading="eager"
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/visionf1/app/analytics/race-head-to-head/page.tsx
+++ b/visionf1/app/analytics/race-head-to-head/page.tsx
@@ -13,8 +13,8 @@ import { Season, EventSummary, RacePaceRow } from "@/lib/types"
 interface TeamComparison {
   teamName: string;
   winner: RacePaceRow;
-  loser: RacePaceRow;
-  delta: number;
+  loser?: RacePaceRow;
+  delta?: number;
 }
 
 export default function RaceHeadToHead() {
@@ -115,9 +115,9 @@ export default function RaceHeadToHead() {
     const comparisons: TeamComparison[] = [];
 
     Object.entries(groupedByTeam).forEach(([teamName, drivers]) => {
-      if (drivers.length >= 2) {
-        const sortedDrivers = [...drivers].sort((a, b) => a.avg_laptime - b.avg_laptime);
+      const sortedDrivers = [...drivers].sort((a, b) => a.avg_laptime - b.avg_laptime);
 
+      if (sortedDrivers.length >= 2) {
         const winner = sortedDrivers[0];
         const loser = sortedDrivers[1];
         const delta = loser.avg_laptime - winner.avg_laptime;
@@ -127,6 +127,12 @@ export default function RaceHeadToHead() {
           winner,
           loser,
           delta
+        });
+      } else if (sortedDrivers.length === 1) {
+        // Single driver case
+        comparisons.push({
+          teamName,
+          winner: sortedDrivers[0]
         });
       }
     });

--- a/visionf1/app/analytics/race-head-to-head/page.tsx
+++ b/visionf1/app/analytics/race-head-to-head/page.tsx
@@ -1,0 +1,223 @@
+"use client"
+
+import { useMemo, useState, useEffect } from "react"
+import Image from "next/image"
+
+import { GenericComboBox } from "@/components/ui/combobox"
+import { Spinner } from "@/components/ui/spinner"
+import { HeadToHeadCard } from "@/components/head-to-head-card"
+
+import { getSeasons, getSummaryEvents, getRacePace } from "@/lib/api-requests"
+import { Season, EventSummary, RacePaceRow } from "@/lib/types"
+
+interface TeamComparison {
+  teamName: string;
+  winner: RacePaceRow;
+  loser: RacePaceRow;
+  delta: number;
+}
+
+export default function RaceHeadToHead() {
+  const [seasons, setSeasons] = useState<Season[]>([]);
+  const [events, setEvents] = useState<EventSummary[]>([]);
+  const [racePaceData, setRacePaceData] = useState<RacePaceRow[]>([]);
+  const [selectedYear, setSelectedYear] = useState<string | null>(null);
+  const [selectedGP, setSelectedGP] = useState<string | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  // Load seasons on component mount
+  useEffect(() => {
+    const loadSeasons = async () => {
+      try {
+        const seasonsResponse = await getSeasons();
+        setSeasons(seasonsResponse.data);
+      } catch (error) {
+        console.error("Error loading seasons:", error);
+      }
+    };
+
+    loadSeasons();
+  }, []);
+
+  // Load events when a year is selected
+  useEffect(() => {
+    const loadEvents = async () => {
+      if (!selectedYear) return;
+
+      try {
+        const eventsResponse = await getSummaryEvents(Number(selectedYear));
+        setEvents(eventsResponse.data);
+        setSelectedGP(null); // Reset selected GP
+        setRacePaceData([]); // Clear previous data
+      } catch (error) {
+        console.error("Error loading events:", error);
+        setEvents([]);
+      }
+    };
+
+    loadEvents();
+  }, [selectedYear]);
+
+  // Load race pace data when a GP is selected
+  useEffect(() => {
+    const loadRacePace = async () => {
+      if (!selectedGP) return;
+
+      try {
+        setLoading(true);
+        const [season, round] = selectedGP.split('_').map(Number);
+        const racePaceResponse = await getRacePace(season, round);
+        setRacePaceData(racePaceResponse.data);
+      } catch (error) {
+        console.error("Error loading race pace data:", error);
+        setRacePaceData([]);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadRacePace();
+  }, [selectedGP]);
+
+  const years = useMemo(() =>
+    seasons.map(season => String(season)).sort((a, b) => Number(b) - Number(a)),
+    [seasons]
+  );
+
+  const gps = useMemo(() =>
+    events.map(event => ({
+      id: `${event.season}_${event.round}`,
+      label: event.event_name,
+      season: event.season,
+      round: event.round
+    })),
+    [events]
+  );
+
+  const currentEvent = events.find(event =>
+    `${event.season}_${event.round}` === selectedGP
+  );
+
+  // Process data for Head to Head
+  const teamComparisons: TeamComparison[] = useMemo(() => {
+    if (!racePaceData.length) return [];
+
+    const groupedByTeam: Record<string, RacePaceRow[]> = {};
+
+    // Group drivers by team
+    racePaceData.forEach(row => {
+      if (!groupedByTeam[row.team_name]) {
+        groupedByTeam[row.team_name] = [];
+      }
+      groupedByTeam[row.team_name].push(row);
+    });
+
+    const comparisons: TeamComparison[] = [];
+
+    Object.entries(groupedByTeam).forEach(([teamName, drivers]) => {
+      if (drivers.length >= 2) {
+        const sortedDrivers = [...drivers].sort((a, b) => a.avg_laptime - b.avg_laptime);
+
+        const winner = sortedDrivers[0];
+        const loser = sortedDrivers[1];
+        const delta = loser.avg_laptime - winner.avg_laptime;
+
+        comparisons.push({
+          teamName,
+          winner,
+          loser,
+          delta
+        });
+      }
+    });
+
+    return comparisons.sort((a, b) => a.teamName.localeCompare(b.teamName));
+
+  }, [racePaceData]);
+
+  return (
+    <div className="flex flex-1 flex-col gap-4 p-4 pt-4">
+      <div className="bg-popover min-h-min flex-1 rounded-xl md:min-h-min p-4">
+        <div className="w-full">
+          <h2 className="text-lg font-semibold pb-4">
+            {currentEvent ? `Race Head to Head - ${currentEvent.season} ${currentEvent.event_name}` : "Race Head to Head"}
+          </h2>
+
+          <div className="flex flex-col sm:flex-row gap-4 mb-4">
+            <GenericComboBox
+              items={years}
+              value={selectedYear}
+              onChange={setSelectedYear}
+              getLabel={(y) => String(y)}
+              getValue={(y) => String(y)}
+              placeholder="Select Year"
+              search_label="Year"
+              width="w-[320px]"
+            />
+
+            <GenericComboBox
+              items={gps}
+              value={selectedGP}
+              onChange={setSelectedGP}
+              getLabel={(g) => `R${g.round} • ${g.label}`}
+              getValue={(g) => g.id}
+              placeholder="Select Grand Prix"
+              search_label="Grand Prix"
+              width="w-[320px]"
+            />
+          </div>
+
+          {loading ? (
+            <div className="flex justify-center items-center h-64">
+              <Spinner className="size-6 mr-2" />
+              <div className="text-lg">Loading race pace data...</div>
+            </div>
+          ) : teamComparisons.length > 0 ? (
+            <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-2 gap-4">
+              {teamComparisons.map((comparison) => (
+                <HeadToHeadCard
+                  key={comparison.teamName}
+                  winner={comparison.winner}
+                  loser={comparison.loser}
+                  delta={comparison.delta}
+                />
+              ))}
+            </div>
+          ) : selectedGP ? (
+            <div className="flex flex-col justify-center items-center text-center h-80 gap-10">
+              <div className="text-lg">No comparable race pace data available for this event.</div>
+              <div className="flex-shrink-0 pb-2 px-2">
+                <div className="h-20 w-20 @2xs:h-24 @2xs:w-24 @xs:h-28 @xs:w-28 @sm:h-36 @sm:w-36 @md:h-42 @md:w-42 @lg:h-46 @lg:w-46 @xl:h-56 @xl:w-56 bg-sidebar-primary border-2 border-brand flex items-center justify-center rounded-full overflow-hidden shadow-lg">
+                  <Image
+                    src="/visionf1-logo.svg"
+                    alt="VisionF1"
+                    width={200}
+                    height={200}
+                    className="object-contain h-full w-full p-1"
+                    loading="eager"
+                  />
+                </div>
+              </div>
+            </div>
+          ) : (
+            <div className="flex flex-col justify-center items-center text-center h-80 gap-10">
+              <div className="text-lg">Please select a Grand Prix to view Head to Head comparisons.</div>
+              <div className="flex-shrink-0 pb-2 px-2">
+                <div className="h-20 w-20 @2xs:h-24 @2xs:w-24 @xs:h-28 @xs:w-28 @sm:h-36 @sm:w-36 @md:h-42 @md:w-42 @lg:h-46 @lg:w-46 @xl:h-56 @xl:w-56 bg-sidebar-primary border-2 border-brand flex items-center justify-center rounded-full overflow-hidden shadow-lg">
+                  <Image
+                    src="/visionf1-logo.svg"
+                    alt="VisionF1"
+                    width={200}
+                    height={200}
+                    className="object-contain h-full w-full p-1"
+                    loading="eager"
+                  />
+                </div>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/visionf1/components/head-to-head-card.tsx
+++ b/visionf1/components/head-to-head-card.tsx
@@ -60,6 +60,18 @@ export function HeadToHeadCard({ winner, loser, delta }: HeadToHeadCardProps) {
           />
         </div>
 
+        {/* Loser Driver Image (Behind Winner, shadowed/smaller) */}
+        <div className="absolute right-[15%] bottom-0 h-[80%] w-[35%] z-15 flex items-end justify-end opacity-80 mix-blend-multiply brightness-70 select-none pointer-events-none">
+          <CldImage
+            src={loser.driver}
+            alt={loser.driver_last_name}
+            width={300}
+            height={300}
+            crop="fill"
+            className="object-contain object-bottom h-full w-auto mask-image-linear-to-b"
+          />
+        </div>
+
         {/* Right Side: Driver Image */}
         <div className="absolute right-2 bottom-0 h-[95%] w-[40%] z-20 flex items-end justify-end">
           <CldImage

--- a/visionf1/components/head-to-head-card.tsx
+++ b/visionf1/components/head-to-head-card.tsx
@@ -27,7 +27,7 @@ export function HeadToHeadCard({ winner, loser, delta }: HeadToHeadCardProps) {
 
       <div className="relative h-full flex items-center justify-between p-6">
         {/* Left Side: Stats & Info */}
-        <div className="flex flex-col justify-center gap-1 z-10 max-w-[60%]">
+        <div className="flex flex-col justify-center gap-1 z-10 max-w-[50%]">
           {/* Winner Name */}
           <h3 className="text-2xl @xs:text-3xl font-black text-white uppercase tracking-tighter leading-none mb-2">
             {winner.driver_last_name}
@@ -49,8 +49,8 @@ export function HeadToHeadCard({ winner, loser, delta }: HeadToHeadCardProps) {
           </div>
         </div>
 
-        {/* Center/Right: Team Logo */}
-        <div className="absolute right-24 top-1/2 -translate-y-1/2 opacity-100 w-16 h-16 pointer-events-none z-10 flex items-center justify-center">
+        {/* Center/Right: Team Logo (Positioned between text and driver) */}
+        <div className="absolute right-[42%] top-1/2 -translate-y-1/2 w-14 h-14 pointer-events-none z-10 flex items-center justify-center">
           <CldImage
             src={winner.team_name.toLowerCase()}
             alt={winner.team_name}

--- a/visionf1/components/head-to-head-card.tsx
+++ b/visionf1/components/head-to-head-card.tsx
@@ -1,0 +1,77 @@
+"use client";
+
+import { CldImage } from "next-cloudinary"
+import { RacePaceRow } from "@/lib/types"
+
+interface HeadToHeadCardProps {
+  winner: RacePaceRow;
+  loser: RacePaceRow;
+  delta: number;
+}
+
+export function HeadToHeadCard({ winner, loser, delta }: HeadToHeadCardProps) {
+  // Ensure team color starts with #
+  const formatColor = (color: string) => color.startsWith('#') ? color : `#${color}`;
+  const bgColor = formatColor(winner.team_color);
+
+  // Format delta to 3 decimal places
+  const formattedDelta = delta.toFixed(3);
+
+  return (
+    <div
+      className="relative overflow-hidden rounded-xl h-48 @container shadow-lg transition-transform hover:scale-[1.02]"
+      style={{ backgroundColor: bgColor }}
+    >
+      {/* Background Gradient Overlay */}
+      <div className="absolute inset-0 bg-gradient-to-r from-black/60 via-black/20 to-transparent" />
+
+      <div className="relative h-full flex items-center justify-between p-6">
+        {/* Left Side: Stats & Info */}
+        <div className="flex flex-col justify-center gap-1 z-10 max-w-[60%]">
+          {/* Winner Name */}
+          <h3 className="text-2xl @xs:text-3xl font-black text-white uppercase tracking-tighter leading-none mb-2">
+            {winner.driver_last_name}
+          </h3>
+
+          {/* Delta */}
+          <div className="flex items-baseline gap-1">
+            <span className="text-4xl @xs:text-5xl @sm:text-6xl font-black text-white tracking-tighter italic leading-none">
+              {formattedDelta}
+            </span>
+            <span className="text-xl @xs:text-2xl font-bold text-white/90 italic">
+              s
+            </span>
+          </div>
+
+          {/* Comparison Text */}
+          <div className="text-sm @xs:text-base font-medium text-white/80 mt-1">
+            faster than <span className="text-white font-bold">{loser.driver_last_name.toUpperCase()}</span>
+          </div>
+        </div>
+
+        {/* Center/Right: Team Logo */}
+        <div className="absolute right-24 top-1/2 -translate-y-1/2 opacity-100 w-16 h-16 pointer-events-none z-10 flex items-center justify-center">
+          <CldImage
+            src={winner.team_name.toLowerCase()}
+            alt={winner.team_name}
+            width={100}
+            height={100}
+            className="object-contain w-full h-full drop-shadow-md"
+          />
+        </div>
+
+        {/* Right Side: Driver Image */}
+        <div className="absolute right-2 bottom-0 h-[95%] w-[40%] z-20 flex items-end justify-end">
+          <CldImage
+            src={winner.driver}
+            alt={winner.driver_last_name}
+            width={400}
+            height={400}
+            crop="fill"
+            className="object-contain object-bottom h-full w-auto drop-shadow-xl mask-image-linear-to-b"
+          />
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/visionf1/components/head-to-head-card.tsx
+++ b/visionf1/components/head-to-head-card.tsx
@@ -5,8 +5,8 @@ import { RacePaceRow } from "@/lib/types"
 
 interface HeadToHeadCardProps {
   winner: RacePaceRow;
-  loser: RacePaceRow;
-  delta: number;
+  loser?: RacePaceRow;
+  delta?: number;
 }
 
 export function HeadToHeadCard({ winner, loser, delta }: HeadToHeadCardProps) {
@@ -14,8 +14,8 @@ export function HeadToHeadCard({ winner, loser, delta }: HeadToHeadCardProps) {
   const formatColor = (color: string) => color.startsWith('#') ? color : `#${color}`;
   const bgColor = formatColor(winner.team_color);
 
-  // Format delta to 3 decimal places
-  const formattedDelta = delta.toFixed(3);
+  // Format delta to 3 decimal places if it exists
+  const formattedDelta = delta !== undefined ? delta.toFixed(3) : null;
 
   return (
     <div
@@ -33,20 +33,40 @@ export function HeadToHeadCard({ winner, loser, delta }: HeadToHeadCardProps) {
             {winner.driver_last_name}
           </h3>
 
-          {/* Delta */}
-          <div className="flex items-baseline gap-1">
-            <span className="text-4xl @xs:text-5xl @sm:text-6xl font-black text-white tracking-tighter italic leading-none">
-              {formattedDelta}
-            </span>
-            <span className="text-xl @xs:text-2xl font-bold text-white/90 italic">
-              s
-            </span>
-          </div>
+          {/* Delta - Show only if exists */}
+          {formattedDelta !== null && loser ? (
+            <>
+              <div className="flex items-baseline gap-1">
+                <span className="text-4xl @xs:text-5xl @sm:text-6xl font-black text-white tracking-tighter italic leading-none">
+                  {formattedDelta}
+                </span>
+                <span className="text-xl @xs:text-2xl font-bold text-white/90 italic">
+                  s
+                </span>
+              </div>
 
-          {/* Comparison Text */}
-          <div className="text-sm @xs:text-base font-medium text-white/80 mt-1">
-            faster than <span className="text-white font-bold">{loser.driver_last_name.toUpperCase()}</span>
-          </div>
+              {/* Comparison Text */}
+              <div className="text-sm @xs:text-base font-medium text-white/80 mt-1">
+                faster than <span className="text-white font-bold">{loser.driver_last_name.toUpperCase()}</span>
+              </div>
+            </>
+          ) : (
+            <div className="flex flex-col gap-1 mt-1">
+              <span className="text-xs @xs:text-sm font-medium text-white/70 uppercase tracking-widest">
+                Avg Pace
+              </span>
+              <span className="text-3xl @xs:text-4xl font-black text-white tracking-tighter italic leading-none">
+                {/* Convert seconds to formatted time if needed, or just display raw/custom format. */}
+                {(() => {
+                  const sec = winner.avg_laptime;
+                  const minutes = Math.floor(sec / 60);
+                  const seconds = Math.floor(sec % 60);
+                  const millis = Math.round((sec - minutes * 60 - seconds) * 1000);
+                  return `${minutes}:${seconds.toString().padStart(2, "0")}.${millis.toString().padStart(3, "0")}`;
+                })()}
+              </span>
+            </div>
+          )}
         </div>
 
         {/* Center/Right: Team Logo (Positioned between text and driver) */}
@@ -60,17 +80,19 @@ export function HeadToHeadCard({ winner, loser, delta }: HeadToHeadCardProps) {
           />
         </div>
 
-        {/* Loser Driver Image (Behind Winner, shadowed/smaller) */}
-        <div className="absolute right-[15%] bottom-0 h-[80%] w-[35%] z-15 flex items-end justify-end opacity-80 mix-blend-multiply brightness-70 select-none pointer-events-none">
-          <CldImage
-            src={loser.driver}
-            alt={loser.driver_last_name}
-            width={300}
-            height={300}
-            crop="fill"
-            className="object-contain object-bottom h-full w-auto mask-image-linear-to-b"
-          />
-        </div>
+        {/* Loser Driver Image (Behind Winner, shadowed/smaller) - Only if loser exists */}
+        {loser && (
+          <div className="absolute right-[15%] bottom-0 h-[80%] w-[35%] z-15 flex items-end justify-end opacity-80 mix-blend-multiply brightness-70 select-none pointer-events-none">
+            <CldImage
+              src={loser.driver}
+              alt={loser.driver_last_name}
+              width={300}
+              height={300}
+              crop="fill"
+              className="object-contain object-bottom h-full w-auto mask-image-linear-to-b"
+            />
+          </div>
+        )}
 
         {/* Right Side: Driver Image */}
         <div className="absolute right-2 bottom-0 h-[95%] w-[40%] z-20 flex items-end justify-end">

--- a/visionf1/components/search-bar.tsx
+++ b/visionf1/components/search-bar.tsx
@@ -53,6 +53,7 @@ export function SearchBar() {
     { name: "Clean Air Race Pace", url: "/analytics/clean-air-race-pace", icon: ChartLineIcon, type: "Page" },
     { name: "Lap Time Distributions", url: "/analytics/lap-time-distributions", icon: ChartLineIcon, type: "Page" },
     { name: "Race Head to Head", url: "/analytics/race-head-to-head", icon: ChartLineIcon, type: "Page" },
+    { name: "Clean Air Head to Head", url: "/analytics/clean-air-head-to-head", icon: ChartLineIcon, type: "Page" },
     { name: "Calendar", url: "/calendar", icon: Calendar, type: "Page" },
     { name: "Drivers", url: "/drivers", icon: Users, type: "Page" },
     { name: "About", url: "/about", icon: InfoIcon, type: "Page" },

--- a/visionf1/components/search-bar.tsx
+++ b/visionf1/components/search-bar.tsx
@@ -52,6 +52,7 @@ export function SearchBar() {
     { name: "Race Pace", url: "/analytics/race-pace", icon: ChartLineIcon, type: "Page" },
     { name: "Clean Air Race Pace", url: "/analytics/clean-air-race-pace", icon: ChartLineIcon, type: "Page" },
     { name: "Lap Time Distributions", url: "/analytics/lap-time-distributions", icon: ChartLineIcon, type: "Page" },
+    { name: "Race Head to Head", url: "/analytics/race-head-to-head", icon: ChartLineIcon, type: "Page" },
     { name: "Calendar", url: "/calendar", icon: Calendar, type: "Page" },
     { name: "Drivers", url: "/drivers", icon: Users, type: "Page" },
     { name: "About", url: "/about", icon: InfoIcon, type: "Page" },

--- a/visionf1/components/sidebar/app-sidebar.tsx
+++ b/visionf1/components/sidebar/app-sidebar.tsx
@@ -82,12 +82,8 @@ const data = {
           url: "/analytics/lap-time-distributions",
         },
         {
-          title: "Quali Head to Head",
-          url: "#",
-        },
-        {
           title: "Race Head to Head",
-          url: "#",
+          url: "/analytics/race-head-to-head",
         },
       ],
     },

--- a/visionf1/components/sidebar/app-sidebar.tsx
+++ b/visionf1/components/sidebar/app-sidebar.tsx
@@ -85,6 +85,10 @@ const data = {
           title: "Race Head to Head",
           url: "/analytics/race-head-to-head",
         },
+        {
+          title: "Clean Air Head to Head",
+          url: "/analytics/clean-air-head-to-head",
+        },
       ],
     },
     {

--- a/visionf1/components/ui/sidebar.tsx
+++ b/visionf1/components/ui/sidebar.tsx
@@ -643,7 +643,7 @@ function SidebarMenuSub({ className, ...props }: React.ComponentProps<"ul">) {
       data-slot="sidebar-menu-sub"
       data-sidebar="menu-sub"
       className={cn(
-        "border-sidebar-border mx-2.5 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5",
+        "border-sidebar-border mx-2 flex min-w-0 translate-x-px flex-col gap-1 border-l px-2.5 py-0.5",
         "group-data-[collapsible=icon]:hidden",
         className
       )}


### PR DESCRIPTION
This pull request introduces new "Head to Head" analytics features for comparing teammates' race pace and clean air performance, enhances the user interface with a dedicated comparison card, and updates project documentation and navigation to reflect these additions.

**New Analytics Pages:**

- Added a "Race Head to Head" page (`visionf1/app/analytics/race-head-to-head/page.tsx`) that allows users to compare teammates' average race pace for any Grand Prix and season. This page fetches race pace data, groups drivers by team, and displays the delta between teammates in an interactive format.
- Added a "Clean Air Head to Head" page (`visionf1/app/analytics/clean-air-head-to-head/page.tsx`) for comparing teammates' performance specifically in clean air conditions, using similar logic and UI as the race head-to-head page.

**User Interface Components:**

- Introduced a reusable `HeadToHeadCard` component (`visionf1/components/head-to-head-card.tsx`) that visually presents the head-to-head comparison, including driver images, team branding, and performance delta.

**Navigation and Discoverability:**

- Updated the `SearchBar` options to include the new "Race Head to Head" and "Clean Air Head to Head" analytics pages, making them easily accessible from the main search/navigation.

**Documentation:**

- Significantly expanded the `README.md` to describe the VisionF1 web application, its features, technology stack, setup instructions, and project structure, providing clearer onboarding and context for contributors.