### PR TITLE
Home cards

### DIFF
--- a/visionf1/app/page.tsx
+++ b/visionf1/app/page.tsx
@@ -3,7 +3,7 @@ import { UpcomingGP } from "@/components/upcoming-gp"
 import { Welcome } from "@/components/welcome"
 import { DriverStandings } from "@/components/driver/driver-standings"
 import { TeamStandings } from "@/components/team-standings"
-import { PlaceholderBrand } from "@/components/placeholder-brand"
+import { HomeCarousel } from "@/components/home-carousel"
 import { getDriverStandings, getTeamStandings, getDrivers, getUpcomingGP } from "@/lib/api-requests"
 
 import { ModelsCard, AnalyticsCard } from "@/components/home-navigation-cards"
@@ -17,26 +17,23 @@ export default async function Home() {
 
   return (
     <div className="flex flex-1 flex-col gap-4 p-4 pt-4">
-      <div className="grid auto-rows-min gap-4 md:grid-cols-2 lg:grid-cols-2 xl:grid-cols-3">
-        <div className="bg-muted/50 aspect-video rounded-xl">
+      <div className="grid gap-4 grid-cols-1 md:grid-cols-2 xl:grid-cols-3 auto-rows-min">
+        <div className="bg-muted/50 aspect-video rounded-xl md:order-1 xl:order-none">
           <Welcome />
         </div>
-        <div className="bg-muted/50 aspect-video rounded-xl">
+        <div className="bg-muted/50 aspect-video rounded-xl md:order-2 xl:order-none">
           <DriverImages data={drivers.data} />
         </div>
-        <div className="bg-muted/50 aspect-video rounded-xl">
+        <div className="bg-muted/50 aspect-video rounded-xl md:order-3 xl:order-none">
           <UpcomingGP gp={upcomingGP.data[0]} />
         </div>
-      </div>
-
-      <div className="grid gap-4 grid-cols-1 md:grid-cols-3 auto-rows-fr">
-        <div className="rounded-xl aspect-video">
+        <div className="rounded-xl aspect-video md:order-5 xl:order-none">
           <ModelsCard />
         </div>
-        <div className="bg-muted/50 rounded-xl overflow-hidden aspect-video">
-          <PlaceholderBrand />
+        <div className="bg-muted/50 rounded-xl overflow-hidden aspect-video md:order-4 xl:order-none">
+          <HomeCarousel />
         </div>
-        <div className="rounded-xl aspect-video">
+        <div className="rounded-xl aspect-video md:order-6 xl:order-none">
           <AnalyticsCard />
         </div>
       </div>

--- a/visionf1/app/page.tsx
+++ b/visionf1/app/page.tsx
@@ -6,6 +6,8 @@ import { TeamStandings } from "@/components/team-standings"
 import { PlaceholderBrand } from "@/components/placeholder-brand"
 import { getDriverStandings, getTeamStandings, getDrivers, getUpcomingGP } from "@/lib/api-requests"
 
+import { ModelsCard, AnalyticsCard } from "@/components/home-navigation-cards"
+
 export default async function Home() {
 
   const driverStandings = await getDriverStandings();
@@ -20,15 +22,25 @@ export default async function Home() {
           <Welcome />
         </div>
         <div className="bg-muted/50 aspect-video rounded-xl">
-          <DriverImages data={drivers.data}/>
+          <DriverImages data={drivers.data} />
         </div>
         <div className="bg-muted/50 aspect-video rounded-xl">
           <UpcomingGP gp={upcomingGP.data[0]} />
         </div>
-        <div className="bg-muted/50 aspect-video rounded-xl hidden md:block lg:block xl:hidden">
+      </div>
+
+      <div className="grid gap-4 grid-cols-1 md:grid-cols-3 auto-rows-fr">
+        <div className="rounded-xl aspect-video">
+          <ModelsCard />
+        </div>
+        <div className="bg-muted/50 rounded-xl overflow-hidden aspect-video">
           <PlaceholderBrand />
         </div>
+        <div className="rounded-xl aspect-video">
+          <AnalyticsCard />
+        </div>
       </div>
+
       <div className="bg-muted/50 min-h-min flex-1 rounded-xl md:min-h-min">
         <DriverStandings data={driverStandings.data} />
       </div>

--- a/visionf1/components/charts/championship-battle-chart.tsx
+++ b/visionf1/components/charts/championship-battle-chart.tsx
@@ -1,0 +1,131 @@
+"use client"
+
+import { Area, AreaChart, XAxis, YAxis } from "recharts"
+import {
+  Card,
+  CardContent,
+} from "@/components/ui/card"
+import {
+  ChartContainer,
+  ChartTooltip,
+  ChartTooltipContent,
+  type ChartConfig,
+} from "@/components/ui/chart"
+
+export const description = "A stacked area chart for championship battle"
+
+// Cumulative points progression for 24 races (2025 Season)
+const chartData = [
+  { race: "AUS", lando: 25, max: 18, oscar: 2 },
+  { race: "CHN", lando: 44, max: 36, oscar: 34 },
+  { race: "JPN", lando: 62, max: 61, oscar: 49 },
+  { race: "BHR", lando: 77, max: 69, oscar: 74 },
+  { race: "KSA", lando: 99, max: 87, oscar: 89 },
+  { race: "MIA", lando: 115, max: 99, oscar: 131 },
+  { race: "EMI", lando: 133, max: 124, oscar: 146 },
+  { race: "MON", lando: 158, max: 136, oscar: 161 },
+  { race: "ESP", lando: 176, max: 137, oscar: 186 },
+  { race: "CAN", lando: 176, max: 155, oscar: 198 },
+  { race: "AUT", lando: 201, max: 155, oscar: 216 },
+  { race: "GBR", lando: 226, max: 165, oscar: 234 },
+  { race: "BEL", lando: 250, max: 185, oscar: 266 },
+  { race: "HUN", lando: 275, max: 187, oscar: 284 },
+  { race: "NED", lando: 275, max: 205, oscar: 309 },
+  { race: "ITA", lando: 293, max: 230, oscar: 324 },
+  { race: "AZE", lando: 299, max: 255, oscar: 324 },
+  { race: "SIN", lando: 314, max: 273, oscar: 336 },
+  { race: "USA", lando: 332, max: 306, oscar: 346 },
+  { race: "MEX", lando: 357, max: 321, oscar: 356 },
+  { race: "BRA", lando: 390, max: 341, oscar: 366 },
+  { race: "LVG", lando: 390, max: 366, oscar: 366 },
+  { race: "QAT", lando: 408, max: 396, oscar: 392 },
+  { race: "ABU", lando: 423, max: 421, oscar: 410 },
+]
+
+const chartConfig = {
+  lando: {
+    label: "Lando Norris",
+    color: "#f97316", // Orange-500
+  },
+  max: {
+    label: "Max Verstappen",
+    color: "#3b82f6", // Blue-500
+  },
+  oscar: {
+    label: "Oscar Piastri",
+    color: "#e5e7eb", // Gray-200
+  },
+} satisfies ChartConfig
+
+export function ChampionshipBattleChart() {
+  return (
+    <Card className="border-0 shadow-none bg-transparent w-full h-full">
+      <CardContent className="p-0 h-full">
+        <ChartContainer config={chartConfig} className="w-full h-full aspect-auto">
+          <AreaChart
+            data={chartData}
+            margin={{ top: 0, right: 0, left: 0, bottom: 0 }}
+          >
+            <defs>
+              <linearGradient id="fillLando" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="var(--color-lando)" stopOpacity={0.6} />
+                <stop offset="95%" stopColor="var(--color-lando)" stopOpacity={0.1} />
+              </linearGradient>
+              <linearGradient id="fillMax" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="var(--color-max)" stopOpacity={0.6} />
+                <stop offset="95%" stopColor="var(--color-max)" stopOpacity={0.1} />
+              </linearGradient>
+              <linearGradient id="fillOscar" x1="0" y1="0" x2="0" y2="1">
+                <stop offset="5%" stopColor="var(--color-oscar)" stopOpacity={0.6} />
+                <stop offset="95%" stopColor="var(--color-oscar)" stopOpacity={0.1} />
+              </linearGradient>
+            </defs>
+            <XAxis
+              dataKey="race"
+              tickLine={false}
+              axisLine={false}
+              tickMargin={8}
+              tick={{ fill: "hsl(var(--muted-foreground))", fontSize: 10, fontWeight: 600 }}
+              interval={"preserveStartEnd"}
+              minTickGap={12}
+            />
+            <YAxis hide domain={[0, 'dataMax']} padding={{ top: 0, bottom: 0 }} />
+            <ChartTooltip
+              content={
+                <ChartTooltipContent
+                  indicator="line"
+                  labelFormatter={(value) => value}
+                />
+              }
+            />
+            {/* Render Order: Lando (Biggest) -> Max -> Oscar (Smallest) to avoid hiding */}
+            <Area
+              dataKey="lando"
+              type="monotone"
+              fill="url(#fillLando)"
+              fillOpacity={0.5}
+              stroke="var(--color-lando)"
+              strokeWidth={3}
+            />
+            <Area
+              dataKey="max"
+              type="monotone"
+              fill="url(#fillMax)"
+              fillOpacity={0.5}
+              stroke="var(--color-max)"
+              strokeWidth={3}
+            />
+            <Area
+              dataKey="oscar"
+              type="monotone"
+              fill="url(#fillOscar)"
+              fillOpacity={0.5}
+              stroke="var(--color-oscar)"
+              strokeWidth={3}
+            />
+          </AreaChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  )
+}

--- a/visionf1/components/home-carousel.tsx
+++ b/visionf1/components/home-carousel.tsx
@@ -1,10 +1,10 @@
 "use client"
 
 import * as React from "react"
-import Image from "next/image"
 import { CldImage } from "next-cloudinary"
 import Autoplay from "embla-carousel-autoplay"
 import { Trophy, Crown } from "lucide-react"
+import { ChampionshipBattleChart } from "@/components/charts/championship-battle-chart"
 
 import {
   Carousel,
@@ -12,8 +12,8 @@ import {
   CarouselItem,
   type CarouselApi,
 } from "@/components/ui/carousel"
-import { Card, CardContent } from "@/components/ui/card"
 import { cn } from "@/lib/utils"
+
 
 export function HomeCarousel() {
   const plugin = React.useRef(
@@ -164,6 +164,30 @@ export function HomeCarousel() {
                 </div>
 
               </div>
+            </div>
+          </CarouselItem>
+
+          {/* Slide 3: Championship Battle Area Chart */}
+          <CarouselItem className="pl-0 h-full">
+            <div className="h-full w-full @container relative overflow-hidden flex flex-col pt-0 px-0">
+
+              {/* Header matching ModelsCard */}
+              <div className="px-4 py-3 pb-0 z-20">
+                <div className="flex items-center gap-2 text-sm font-medium text-foreground/90">
+                  <div className="p-1 rounded-md bg-orange-500/10 text-orange-500">
+                    <Trophy className="h-4 w-4" />
+                  </div>
+                  Championship Battle
+                </div>
+              </div>
+
+              {/* Chart Container */}
+              <div className="flex-1 w-full min-h-0 flex items-center justify-center">
+                <div className="w-full h-full pb-0 px-6">
+                  <ChampionshipBattleChart />
+                </div>
+              </div>
+
             </div>
           </CarouselItem>
 

--- a/visionf1/components/home-carousel.tsx
+++ b/visionf1/components/home-carousel.tsx
@@ -1,0 +1,191 @@
+"use client"
+
+import * as React from "react"
+import Image from "next/image"
+import { CldImage } from "next-cloudinary"
+import Autoplay from "embla-carousel-autoplay"
+import { Trophy, Crown } from "lucide-react"
+
+import {
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  type CarouselApi,
+} from "@/components/ui/carousel"
+import { Card, CardContent } from "@/components/ui/card"
+import { cn } from "@/lib/utils"
+
+export function HomeCarousel() {
+  const plugin = React.useRef(
+    Autoplay({ delay: 3000, stopOnInteraction: true })
+  )
+  const [api, setApi] = React.useState<CarouselApi>()
+  const [current, setCurrent] = React.useState(0)
+  const [count, setCount] = React.useState(0)
+
+  React.useEffect(() => {
+    if (!api) {
+      return
+    }
+
+    setCount(api.scrollSnapList().length)
+    setCurrent(api.selectedScrollSnap() + 1)
+
+    api.on("select", () => {
+      setCurrent(api.selectedScrollSnap() + 1)
+    })
+  }, [api])
+
+  return (
+    <div className="group relative w-full h-full rounded-xl overflow-hidden">
+      <Carousel
+        setApi={setApi}
+        plugins={[plugin.current]}
+        className="w-full h-full [&>div]:h-full"
+        onMouseEnter={plugin.current.stop}
+        onMouseLeave={plugin.current.reset}
+      >
+        <CarouselContent className="h-full ml-0">
+
+          {/* Slide 1: Lando Norris Champion Card */}
+          <CarouselItem className="pl-0 h-full">
+            <div className="h-full w-full @container relative overflow-hidden flex flex-col pt-4 px-6">
+
+              {/* Background Decorations */}
+              <div className="absolute top-0 right-0 p-4 opacity-10 rotate-12 pointer-events-none">
+                <Trophy className="w-48 h-48 text-yellow-500" />
+              </div>
+
+              {/* Title Section (Full Width, Centered) */}
+              <div className="z-10 w-full flex items-center justify-center gap-3 mb-1 shrink-0">
+                <Crown className="w-4 h-4 text-yellow-500 fill-yellow-500 animate-pulse" />
+                <span className="text-yellow-500 font-bold tracking-[0.2em] uppercase text-xs @sm:text-sm shadow-black drop-shadow-sm text-center">2025 World Drivers' Champion</span>
+                <Crown className="w-4 h-4 text-yellow-500 fill-yellow-500 animate-pulse" />
+              </div>
+
+              {/* Content Split: Left (Centered Text) vs Right (Bottom Image) */}
+              <div className="flex-1 w-full flex justify-between z-10 min-h-0">
+
+                {/* Left: Name & Team (Vertically Centered) */}
+                <div className="flex flex-col justify-center gap-2">
+                  <div className="flex flex-col leading-none">
+                    <span className="text-muted-foreground text-lg @md:text-xl font-light tracking-wide uppercase">Lando</span>
+                    <span className="text-foreground text-3xl @md:text-4xl @lg:text-5xl font-black italic uppercase tracking-tighter">Norris</span>
+                  </div>
+
+                  <div className="flex items-center gap-2 mt-2 opacity-100">
+                    <div className="h-8 w-8 relative transition-all">
+                      <CldImage
+                        src="McLaren"
+                        alt="McLaren"
+                        width={40}
+                        height={40}
+                        className="object-contain"
+                      />
+                    </div>
+                    <span className="text-sm font-semibold text-muted-foreground">McLaren</span>
+                  </div>
+                </div>
+
+                {/* Right: Image (Bottom Aligned) */}
+                <div className="h-full flex items-end justify-end">
+                  <div className="relative h-40 w-40 @md:h-52 @md:w-52 filter drop-shadow-[0_0_15px_rgba(255,165,0,0.3)]">
+                    <CldImage
+                      src="NOR"
+                      alt="Lando Norris"
+                      fill
+                      className="object-contain object-bottom"
+                    />
+                  </div>
+                </div>
+
+              </div>
+
+            </div>
+          </CarouselItem>
+
+          {/* Slide 2: McLaren Constructors Champion Card */}
+          <CarouselItem className="pl-0 h-full">
+            <div className="h-full w-full @container relative overflow-hidden flex flex-col pt-4 px-6">
+
+              {/* Background Decorations */}
+              <div className="absolute top-0 right-0 p-4 opacity-10 rotate-12 pointer-events-none">
+                <Trophy className="w-48 h-48 text-yellow-500" />
+              </div>
+
+              {/* Title Section (Full Width, Centered) */}
+              <div className="z-10 w-full flex items-center justify-center gap-3 mb-1 shrink-0">
+                <Crown className="w-4 h-4 text-yellow-500 fill-yellow-500 animate-pulse" />
+                <span className="text-yellow-500 font-bold tracking-[0.2em] uppercase text-xs @sm:text-sm shadow-black drop-shadow-sm text-center">2025 World Constructors' Champion</span>
+                <Crown className="w-4 h-4 text-yellow-500 fill-yellow-500 animate-pulse" />
+              </div>
+
+              {/* Content Split: Left (Centered Text) vs Right (Stack: Logo + Car) */}
+              <div className="flex-1 w-full flex justify-between z-10 min-h-0">
+
+                {/* Left: Team Name & Drivers */}
+                <div className="flex flex-col justify-center gap-4">
+                  <div className="flex flex-col leading-none">
+                    <span className="text-foreground text-3xl @md:text-4xl @lg:text-5xl font-black italic tracking-tighter">McLaren</span>
+                  </div>
+
+                  {/* Drivers */}
+                  <div className="flex flex-col gap-1 opacity-90">
+                    <span className="text-sm @md:text-base font-medium text-muted-foreground flex items-center gap-2">
+                      <span className="w-1.5 h-1.5 rounded-full bg-orange-500" /> Lando Norris
+                    </span>
+                    <span className="text-sm @md:text-base font-medium text-muted-foreground flex items-center gap-2">
+                      <span className="w-1.5 h-1.5 rounded-full bg-orange-500" /> Oscar Piastri
+                    </span>
+                  </div>
+                </div>
+
+                {/* Right: Stack (Hero Logo + Car) */}
+                <div className="h-full flex flex-col items-end justify-end mb-10 mr-2 @md:mr-12 gap-4 z-10">
+                  {/* Big McLaren Logo (Hero) */}
+                  <div className="relative h-32 w-32 @md:h-48 @md:w-48 filter drop-shadow-[0_0_25px_rgba(255,165,0,0.2)]">
+                    <CldImage
+                      src="McLaren"
+                      alt="McLaren Logo"
+                      fill
+                      className="object-contain object-bottom"
+                    />
+                  </div>
+
+                  {/* Car Image */}
+                  <div className="relative h-14 w-36 @md:h-20 @md:w-56 opacity-100 transition-all hover:scale-105 origin-right duration-300">
+                    <CldImage
+                      src="mclaren car"
+                      alt="McLaren MCL38"
+                      fill
+                      className="object-contain object-right"
+                    />
+                  </div>
+                </div>
+
+              </div>
+            </div>
+          </CarouselItem>
+
+        </CarouselContent>
+      </Carousel>
+
+      {/* Dots Indicator */}
+      <div className="absolute bottom-3 left-1/2 -translate-x-1/2 flex items-center gap-1.5 z-20">
+        {Array.from({ length: count }).map((_, index) => (
+          <button
+            key={index}
+            className={cn(
+              "h-1.5 rounded-full transition-all duration-300",
+              current === index + 1
+                ? "bg-foreground w-6"
+                : "bg-foreground/20 hover:bg-foreground/40 w-1.5"
+            )}
+            onClick={() => api?.scrollTo(index)}
+            aria-label={`Go to slide ${index + 1}`}
+          />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/visionf1/components/home-carousel.tsx
+++ b/visionf1/components/home-carousel.tsx
@@ -17,7 +17,7 @@ import { cn } from "@/lib/utils"
 
 export function HomeCarousel() {
   const plugin = React.useRef(
-    Autoplay({ delay: 3000, stopOnInteraction: true })
+    Autoplay({ delay: 7000, stopOnInteraction: true })
   )
   const [api, setApi] = React.useState<CarouselApi>()
   const [current, setCurrent] = React.useState(0)
@@ -47,7 +47,31 @@ export function HomeCarousel() {
       >
         <CarouselContent className="h-full ml-0">
 
-          {/* Slide 1: Lando Norris Champion Card */}
+          {/* Slide 1: Championship Battle Area Chart */}
+          <CarouselItem className="pl-0 h-full">
+            <div className="h-full w-full @container relative overflow-hidden flex flex-col pt-0 px-0">
+
+              {/* Header matching ModelsCard */}
+              <div className="px-4 py-3 pb-0 z-20">
+                <div className="flex items-center gap-2 text-sm font-medium text-foreground/90">
+                  <div className="p-1 rounded-md bg-orange-500/10 text-orange-500">
+                    <Trophy className="h-4 w-4" />
+                  </div>
+                  Championship Battle
+                </div>
+              </div>
+
+              {/* Chart Container */}
+              <div className="flex-1 w-full min-h-0 flex items-center justify-center">
+                <div className="w-full h-full pb-0 px-6">
+                  <ChampionshipBattleChart />
+                </div>
+              </div>
+
+            </div>
+          </CarouselItem>
+
+          {/* Slide 2: Lando Norris Champion Card */}
           <CarouselItem className="pl-0 h-full">
             <div className="h-full w-full @container relative overflow-hidden flex flex-col pt-4 px-6">
 
@@ -104,7 +128,7 @@ export function HomeCarousel() {
             </div>
           </CarouselItem>
 
-          {/* Slide 2: McLaren Constructors Champion Card */}
+          {/* Slide 3: McLaren Constructors Champion Card */}
           <CarouselItem className="pl-0 h-full">
             <div className="h-full w-full @container relative overflow-hidden flex flex-col pt-4 px-6">
 
@@ -164,30 +188,6 @@ export function HomeCarousel() {
                 </div>
 
               </div>
-            </div>
-          </CarouselItem>
-
-          {/* Slide 3: Championship Battle Area Chart */}
-          <CarouselItem className="pl-0 h-full">
-            <div className="h-full w-full @container relative overflow-hidden flex flex-col pt-0 px-0">
-
-              {/* Header matching ModelsCard */}
-              <div className="px-4 py-3 pb-0 z-20">
-                <div className="flex items-center gap-2 text-sm font-medium text-foreground/90">
-                  <div className="p-1 rounded-md bg-orange-500/10 text-orange-500">
-                    <Trophy className="h-4 w-4" />
-                  </div>
-                  Championship Battle
-                </div>
-              </div>
-
-              {/* Chart Container */}
-              <div className="flex-1 w-full min-h-0 flex items-center justify-center">
-                <div className="w-full h-full pb-0 px-6">
-                  <ChampionshipBattleChart />
-                </div>
-              </div>
-
             </div>
           </CarouselItem>
 

--- a/visionf1/components/home-navigation-cards.tsx
+++ b/visionf1/components/home-navigation-cards.tsx
@@ -1,7 +1,7 @@
 "use client"
 
 import Link from "next/link"
-import { BrainCircuit, Flag, Timer, LineChart, Gauge, ArrowRight, Sparkles } from "lucide-react"
+import { BrainCircuit, Flag, Timer, LineChart, Gauge, ArrowRight, Zap, Layers, Wind, BarChart3, Swords, Crosshair } from "lucide-react"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { motion } from "framer-motion"
 import { cn } from "@/lib/utils"
@@ -23,8 +23,8 @@ function NavItem({ href, icon: Icon, title, description, colorClass }: NavItemPr
         transition={{ duration: 0.2 }}
         className="flex items-center justify-between p-2 rounded-lg bg-card hover:bg-accent/50 border border-border/50 hover:border-brand/30 transition-all duration-200 shadow-sm hover:shadow-md mb-2"
       >
-        <div className="flex items-center gap-3">
-          <div className={cn("p-2 rounded-md transition-colors duration-300", colorClass)}>
+        <div className="flex items-center gap-2.5">
+          <div className={cn("p-1.5 rounded-md transition-colors duration-300", colorClass)}>
             <Icon className="h-4 w-4" />
           </div>
           <div className="flex flex-col">
@@ -42,9 +42,9 @@ function NavItem({ href, icon: Icon, title, description, colorClass }: NavItemPr
 
 export function ModelsCard() {
   return (
-    <Card className="h-full bg-muted/50 border-none shadow-sm flex flex-col overflow-hidden relative group/card">
+    <Card className="h-full bg-muted/50 border-none shadow-sm flex flex-col overflow-hidden relative group/card @container py-0 gap-0">
 
-      <CardHeader className="px-4">
+      <CardHeader className="px-3 py-3 pb-2">
         <CardTitle className="flex items-center gap-2 text-sm font-medium text-foreground/90">
           <div className="p-1 rounded-md bg-brand/10 text-brand">
             <BrainCircuit className="h-4 w-4" />
@@ -53,14 +53,28 @@ export function ModelsCard() {
         </CardTitle>
       </CardHeader>
 
-      <CardContent className="flex-1 px-4 pb-3 flex flex-col justify-center">
-        <div className="flex flex-col">
+      <CardContent className="flex-1 px-3 pb-2 flex flex-col justify-start overflow-y-auto scrollbar-thin scrollbar-thumb-rounded-md scrollbar-thumb-muted-foreground/20">
+        <div className="flex flex-col gap-0.5">
           <NavItem
             href="/models/race-predictions"
             icon={Flag}
             title="Race Predictions"
             description="AI-powered race outcomes"
             colorClass="bg-blue-500/10 text-blue-500 group-hover:bg-blue-500/20"
+          />
+          <NavItem
+            href="/models/quali-predictions"
+            icon={Zap}
+            title="Quali Predictions"
+            description="Qualification results forecast"
+            colorClass="bg-purple-500/10 text-purple-500 group-hover:bg-purple-500/20"
+          />
+          <NavItem
+            href="/models/race-quali-predictions"
+            icon={Layers}
+            title="Race + Quali"
+            description="Combined event predictions"
+            colorClass="bg-indigo-500/10 text-indigo-500 group-hover:bg-indigo-500/20"
           />
           <NavItem
             href="/models/race-strategy"
@@ -77,9 +91,9 @@ export function ModelsCard() {
 
 export function AnalyticsCard() {
   return (
-    <Card className="h-full bg-muted/50 border-none shadow-sm flex flex-col overflow-hidden relative group/card">
+    <Card className="h-full bg-muted/50 border-none shadow-sm flex flex-col overflow-hidden relative group/card @container py-0 gap-0">
 
-      <CardHeader className="px-4">
+      <CardHeader className="px-3 py-3 pb-2">
         <CardTitle className="flex items-center gap-2 text-sm font-medium text-foreground/90">
           <div className="p-1 rounded-md bg-brand/10 text-brand">
             <LineChart className="h-4 w-4" />
@@ -88,8 +102,8 @@ export function AnalyticsCard() {
         </CardTitle>
       </CardHeader>
 
-      <CardContent className="flex-1 px-4 pb-3 flex flex-col justify-center">
-        <div className="flex flex-col">
+      <CardContent className="flex-1 px-3 pb-2 flex flex-col justify-start overflow-y-auto scrollbar-thin scrollbar-thumb-rounded-md scrollbar-thumb-muted-foreground/20">
+        <div className="flex flex-col gap-0.5">
           <NavItem
             href="/analytics/race-pace"
             icon={Gauge}
@@ -97,21 +111,34 @@ export function AnalyticsCard() {
             description="Lap time analysis"
             colorClass="bg-emerald-500/10 text-emerald-500 group-hover:bg-emerald-500/20"
           />
-
-          {/* Placeholder */}
-          <div className="px-0">
-            <div className="flex items-center justify-between p-2 rounded-lg bg-muted/30 border border-transparent opacity-60 mt-1 mb-2">
-              <div className="flex items-center gap-3">
-                <div className="p-2 rounded-md bg-muted text-muted-foreground">
-                  <Sparkles className="h-4 w-4" />
-                </div>
-                <div className="flex flex-col">
-                  <span className="font-semibold text-xs text-muted-foreground">More Coming Soon</span>
-                  <span className="text-[10px] text-muted-foreground/70 leading-tight">Advanced telemetry insights</span>
-                </div>
-              </div>
-            </div>
-          </div>
+          <NavItem
+            href="/analytics/clean-air-race-pace"
+            icon={Wind}
+            title="Clean Air Race Pace"
+            description="Unimpeded pace analysis"
+            colorClass="bg-teal-500/10 text-teal-500 group-hover:bg-teal-500/20"
+          />
+          <NavItem
+            href="/analytics/lap-time-distributions"
+            icon={BarChart3}
+            title="Lap Time Distributions"
+            description="Consistency & performance"
+            colorClass="bg-cyan-500/10 text-cyan-500 group-hover:bg-cyan-500/20"
+          />
+          <NavItem
+            href="/analytics/race-head-to-head"
+            icon={Swords}
+            title="Race Head to Head"
+            description="Driver performance comparison"
+            colorClass="bg-rose-500/10 text-rose-500 group-hover:bg-rose-500/20"
+          />
+          <NavItem
+            href="/analytics/clean-air-head-to-head"
+            icon={Crosshair}
+            title="Clean Air Head to Head"
+            description="Pure pace comparison"
+            colorClass="bg-pink-500/10 text-pink-500 group-hover:bg-pink-500/20"
+          />
         </div>
       </CardContent>
     </Card>

--- a/visionf1/components/home-navigation-cards.tsx
+++ b/visionf1/components/home-navigation-cards.tsx
@@ -1,0 +1,119 @@
+"use client"
+
+import Link from "next/link"
+import { BrainCircuit, Flag, Timer, LineChart, Gauge, ArrowRight, Sparkles } from "lucide-react"
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
+import { motion } from "framer-motion"
+import { cn } from "@/lib/utils"
+
+interface NavItemProps {
+  href: string
+  icon: React.ElementType
+  title: string
+  description: string
+  colorClass: string
+}
+
+function NavItem({ href, icon: Icon, title, description, colorClass }: NavItemProps) {
+  return (
+    <Link href={href} className="block group">
+      <motion.div
+        whileHover={{ scale: 1.01, x: 2 }}
+        whileTap={{ scale: 0.99 }}
+        transition={{ duration: 0.2 }}
+        className="flex items-center justify-between p-2 rounded-lg bg-card hover:bg-accent/50 border border-border/50 hover:border-brand/30 transition-all duration-200 shadow-sm hover:shadow-md mb-2"
+      >
+        <div className="flex items-center gap-3">
+          <div className={cn("p-2 rounded-md transition-colors duration-300", colorClass)}>
+            <Icon className="h-4 w-4" />
+          </div>
+          <div className="flex flex-col">
+            <span className="font-semibold text-xs group-hover:text-brand transition-colors">{title}</span>
+            <span className="text-[10px] text-muted-foreground leading-tight">{description}</span>
+          </div>
+        </div>
+        <div className="flex items-center justify-center p-1 rounded-full bg-background/50 group-hover:bg-brand/10 transition-colors">
+          <ArrowRight className="h-3 w-3 text-muted-foreground group-hover:text-brand transition-colors duration-200" />
+        </div>
+      </motion.div>
+    </Link>
+  )
+}
+
+export function ModelsCard() {
+  return (
+    <Card className="h-full bg-muted/50 border-none shadow-sm flex flex-col overflow-hidden relative group/card">
+
+      <CardHeader className="px-4">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium text-foreground/90">
+          <div className="p-1 rounded-md bg-brand/10 text-brand">
+            <BrainCircuit className="h-4 w-4" />
+          </div>
+          Models & Predictions
+        </CardTitle>
+      </CardHeader>
+
+      <CardContent className="flex-1 px-4 pb-3 flex flex-col justify-center">
+        <div className="flex flex-col">
+          <NavItem
+            href="/models/race-predictions"
+            icon={Flag}
+            title="Race Predictions"
+            description="AI-powered race outcomes"
+            colorClass="bg-blue-500/10 text-blue-500 group-hover:bg-blue-500/20"
+          />
+          <NavItem
+            href="/models/race-strategy"
+            icon={Timer}
+            title="Race Strategy"
+            description="Optimal pit stop strategies"
+            colorClass="bg-orange-500/10 text-orange-500 group-hover:bg-orange-500/20"
+          />
+        </div>
+      </CardContent>
+    </Card>
+  )
+}
+
+export function AnalyticsCard() {
+  return (
+    <Card className="h-full bg-muted/50 border-none shadow-sm flex flex-col overflow-hidden relative group/card">
+
+      <CardHeader className="px-4">
+        <CardTitle className="flex items-center gap-2 text-sm font-medium text-foreground/90">
+          <div className="p-1 rounded-md bg-brand/10 text-brand">
+            <LineChart className="h-4 w-4" />
+          </div>
+          Analytics & Insights
+        </CardTitle>
+      </CardHeader>
+
+      <CardContent className="flex-1 px-4 pb-3 flex flex-col justify-center">
+        <div className="flex flex-col">
+          <NavItem
+            href="/analytics/race-pace"
+            icon={Gauge}
+            title="Race Pace"
+            description="Lap time analysis"
+            colorClass="bg-emerald-500/10 text-emerald-500 group-hover:bg-emerald-500/20"
+          />
+
+          {/* Placeholder */}
+          <div className="px-0">
+            <div className="flex items-center justify-between p-2 rounded-lg bg-muted/30 border border-transparent opacity-60 mt-1 mb-2">
+              <div className="flex items-center gap-3">
+                <div className="p-2 rounded-md bg-muted text-muted-foreground">
+                  <Sparkles className="h-4 w-4" />
+                </div>
+                <div className="flex flex-col">
+                  <span className="font-semibold text-xs text-muted-foreground">More Coming Soon</span>
+                  <span className="text-[10px] text-muted-foreground/70 leading-tight">Advanced telemetry insights</span>
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  )
+}

--- a/visionf1/package-lock.json
+++ b/visionf1/package-lock.json
@@ -21,6 +21,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "cmdk": "^1.1.1",
+        "embla-carousel-autoplay": "^8.6.0",
         "embla-carousel-react": "^8.6.0",
         "framer-motion": "^12.23.24",
         "lucide-react": "^0.539.0",
@@ -106,6 +107,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -3179,6 +3181,7 @@
       "integrity": "sha512-MWtvHrGZLFttgeEj28VXHxpmwYbor/ATPYbBfSFZEIRK0ecCFLl2Qo55z52Hss+UV9CRN7trSeq1zbgx7YDWWg==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -3189,6 +3192,7 @@
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -3259,6 +3263,7 @@
       "integrity": "sha512-6m1I5RmHBGTnUGS113G04DMu3CpSdxCAU/UvtjNWL4Nuf3MW9tQhiJqRlHzChIkhy6kZSAQmc+I1bcGjE3yNKg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.3",
         "@typescript-eslint/types": "8.46.3",
@@ -3782,6 +3787,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4208,6 +4214,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -5113,7 +5120,17 @@
       "version": "8.6.0",
       "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
       "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/embla-carousel-autoplay": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-autoplay/-/embla-carousel-autoplay-8.6.0.tgz",
+      "integrity": "sha512-OBu5G3nwaSXkZCo1A6LTaFMZ8EpkYbwIaH+bPqdBnDGQ2fh4+NbzjXjs2SktoPNKCtflfVMc75njaDHOYXcrsA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
+      }
     },
     "node_modules/embla-carousel-react": {
       "version": "8.6.0",
@@ -5446,6 +5463,7 @@
       "integrity": "sha512-LSehfdpgMeWcTZkWZVIJl+tkZ2nuSkyyB9C27MZqFWXuph7DvaowgcTvKqxvpLW1JZIk8PN7hFY3Rj9LQ7m7lg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5632,6 +5650,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -8982,6 +9001,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.1.tgz",
       "integrity": "sha512-DGrYcCWK7tvYMnWh79yrPHt+vdx9tY+1gPZa7nJQtO/p8bLTDaHp4dzwEhQB7pZ4Xe3ok4XKuEPrVuc+wlpkmw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8991,6 +9011,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.1.tgz",
       "integrity": "sha512-ibrK8llX2a4eOskq1mXKu/TGZj9qzomO+sNfO98M6d9zIPOEhlBkMkBUBLd1vgS0gQsLDBzA+8jJBVXDnfHmJg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10196,6 +10217,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10412,6 +10434,7 @@
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -10831,6 +10854,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
       "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/visionf1/package.json
+++ b/visionf1/package.json
@@ -22,6 +22,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",
+    "embla-carousel-autoplay": "^8.6.0",
     "embla-carousel-react": "^8.6.0",
     "framer-motion": "^12.23.24",
     "lucide-react": "^0.539.0",


### PR DESCRIPTION
This pull request introduces a major update to the home page of the application, focusing on improving the user experience and adding new interactive and analytical features. The main changes include a redesigned home page layout, the addition of a carousel component with engaging slides, new navigation cards for models and analytics, and a new championship battle chart. Additionally, necessary dependencies have been updated to support these new features.

**Home Page Redesign and Feature Additions:**

- Redesigned the home page grid layout to better organize content and incorporate new components, including a carousel and navigation cards for models and analytics. The previous placeholder brand component was removed. (`visionf1/app/page.tsx`) [[1]](diffhunk://#diff-9c0a78e24b98c1b186455a1aea4dfdf80d5439276410aa89377b068283fc61afL6-R10) [[2]](diffhunk://#diff-9c0a78e24b98c1b186455a1aea4dfdf80d5439276410aa89377b068283fc61afL18-R40)

**New Components:**

- Added `HomeCarousel`, a new interactive carousel on the home page featuring:
  - A championship battle area chart.
  - Highlight cards for the 2025 World Drivers' and Constructors' Champions.
  - Custom navigation dots and visual enhancements. (`visionf1/components/home-carousel.tsx`)
- Introduced `ModelsCard` and `AnalyticsCard` components, providing quick navigation to model predictions and analytics pages with visually distinct, icon-based cards. (`visionf1/components/home-navigation-cards.tsx`)
- Created `ChampionshipBattleChart`, a stacked area chart visualizing the cumulative points progression for top drivers across the 2025 season. (`visionf1/components/charts/championship-battle-chart.tsx`)

**Dependency Updates:**

- Added and configured the `embla-carousel-autoplay` package to enable carousel autoplay functionality. (`visionf1/package-lock.json`)
- Updated several dependencies to include `peer` flags for improved compatibility and stability. (`visionf1/package-lock.json`) [[1]](diffhunk://#diff-550f3430c92dd77ed9cd616437086c5dd53657082f1e0cf6be6576e49da321b4R110) [[2]](diffhunk://#diff-550f3430c92dd77ed9cd616437086c5dd53657082f1e0cf6be6576e49da321b4R3184) [[3]](diffhunk://#diff-550f3430c92dd77ed9cd616437086c5dd53657082f1e0cf6be6576e49da321b4R3195) [[4]](diffhunk://#diff-550f3430c92dd77ed9cd616437086c5dd53657082f1e0cf6be6576e49da321b4R3266)